### PR TITLE
Update aws-vpc-move-ip

### DIFF
--- a/aws-vpc-move-ip
+++ b/aws-vpc-move-ip
@@ -135,7 +135,7 @@ ec2ip_monitor() {
 	debugger "function: ec2ip_monitor: check routing table"
 	cmd="aws $AWS_PROFILE_OPT ec2 describe-route-tables --route-table-ids $OCF_RESKEY_routing_table"
 	debugger "executing command: $cmd"
-	ROUTE_TO_INSTANCE="$($cmd |grep $OCF_RESKEY_address | awk '{ print $3 }')"
+	ROUTE_TO_INSTANCE="$($cmd |grep -w $OCF_RESKEY_address | awk '{ print $3 }')"
 	if [ -z "$ROUTE_TO_INSTANCE" ]; then 
 		ROUTE_TO_INSTANCE="<unknown>"
 	fi


### PR DESCRIPTION
Line 138: ROUTE_TO_INSTANCE="$($cmd |grep -w $OCF_RESKEY_address | awk '{ print $3 }')"

The -w flag ensures that the grep doesn't inadvertently pick up multiple instance. For example an OCF_RESKEY_address value of 192.168.0.1 will match 192.168.0.10, 192.168.0.11 etc. The -w flag ensures that the address is an exact match, as the '/' character is a non-word character.